### PR TITLE
fix bug in word search solution for javascript

### DIFF
--- a/Word Search - Leetcode 79/Word Search - Leetcode 79.js
+++ b/Word Search - Leetcode 79/Word Search - Leetcode 79.js
@@ -4,7 +4,7 @@ var exist = function(board, word) {
     const W = word.length;
 
     if (m === 1 && n === 1) {
-        return board[0][0] === word[0];
+        return board[0][0] === word;
     }
 
     const backtrack = function(i, j, index) {


### PR DESCRIPTION
fix for word search this solution only checks if the only letter on the word is equal to the first letter of the word not the whole word