### PR TITLE
Update Pacific Atlantic Water Flow - Leetcode 417.py

### DIFF
--- a/Pacific Atlantic Water Flow - Leetcode 417/Pacific Atlantic Water Flow - Leetcode 417.py
+++ b/Pacific Atlantic Water Flow - Leetcode 417/Pacific Atlantic Water Flow - Leetcode 417.py
@@ -27,7 +27,6 @@ class Solution:
             a_seen.add((m - 1, j))
 
         def get_coords(que, seen):
-            coords = set()
             while que:
                 i, j = que.popleft()
                 for i_off, j_off in [(0, 1), (1, 0), (-1, 0), (0, -1)]:


### PR DESCRIPTION
I was following the [tutorial on Pacific Atlantic waterflow - Leetcode 417](https://www.youtube.com/watch?v=pDvvDvgHUKE&list=PLKYEe2WisBTFEr6laH5bR2J19j7sl5O8R&index=105) and saw that the video recommended looking at this GitHub repo for a cleaner solution. The code seems to have an artifact from the video. This change just removes that so that it is less confusing.

TL;DR:

Removes `coords = set()` as described in Youtube tutorial since it is not used in the `get_coords()` function anymore

I cannot thank you enough for the video lessons!